### PR TITLE
fix: guard reopened worktrees from shell pane detection

### DIFF
--- a/__tests__/reopenWorktree.test.ts
+++ b/__tests__/reopenWorktree.test.ts
@@ -1,4 +1,5 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { DMUX_BOOTSTRAP_PANE_TITLE_PREFIX } from '../src/utils/paneBootstrapConfig.js';
 
 const fsMock = vi.hoisted(() => ({
   readFileSync: vi.fn(() => JSON.stringify({ controlPaneId: '%0' })),
@@ -9,7 +10,7 @@ const tmuxServiceMock = vi.hoisted(() => ({
   getCurrentSessionNameSync: vi.fn(() => 'dmux-test'),
   paneExists: vi.fn(async () => true),
   setSessionOptionSync: vi.fn(),
-  setPaneTitle: vi.fn(async () => {}),
+  setPaneTitle: vi.fn(async (_paneId: string, _title: string) => {}),
   refreshClient: vi.fn(async () => {}),
   sendShellCommand: vi.fn(async () => {}),
   sendTmuxKeys: vi.fn(async () => {}),
@@ -17,6 +18,7 @@ const tmuxServiceMock = vi.hoisted(() => ({
 }));
 
 const splitPaneMock = vi.hoisted(() => vi.fn(() => '%1'));
+const execSyncMock = vi.hoisted(() => vi.fn());
 const setupSidebarLayoutMock = vi.hoisted(() => vi.fn(() => '%1'));
 const recalculateAndApplyLayoutMock = vi.hoisted(() => vi.fn(async () => {}));
 const getInstalledAgentsMock = vi.hoisted(() => vi.fn(async () => ['claude', 'codex']));
@@ -26,7 +28,13 @@ const readWorktreeMetadataMock = vi.hoisted(() => vi.fn(() => ({
   agent: 'codex',
   permissionMode: 'bypassPermissions',
   branchName: 'feature/reopen-me',
+  mergeTargetChain: [{ branchName: 'main', worktreePath: '/repo' }],
 })));
+
+vi.mock('child_process', async (importOriginal) => ({
+  ...await importOriginal<typeof import('child_process')>(),
+  execSync: execSyncMock,
+}));
 
 vi.mock('fs', () => ({
   default: fsMock,
@@ -99,12 +107,58 @@ vi.mock('../src/utils/welcomePaneManager.js', () => ({
 describe('reopenWorktree', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    tmuxServiceMock.setPaneTitle.mockReset().mockResolvedValue(undefined);
+    execSyncMock.mockReset();
     fsMock.readFileSync.mockReturnValue(JSON.stringify({ controlPaneId: '%0' }));
     readWorktreeMetadataMock.mockReturnValue({
       agent: 'codex',
       permissionMode: 'bypassPermissions',
       branchName: 'feature/reopen-me',
+      mergeTargetChain: [{ branchName: 'main', worktreePath: '/repo' }],
     });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it.each([true, false])('keeps a reopened worktree out of shell detection until saved (first pane: %s)', async (firstPane) => {
+    const { reopenWorktree } = await import('../src/utils/reopenWorktree.js');
+    const { getUntrackedPanes } = await import('../src/utils/shellPaneDetection.js');
+    vi.useFakeTimers();
+
+    let title = 'zsh';
+    tmuxServiceMock.setPaneTitle.mockImplementation(async (_paneId, nextTitle) => {
+      title = nextTitle;
+    });
+    execSyncMock.mockImplementation(() => `%1::${title}::zsh\n%2::manual-shell::zsh`);
+    const manualShell = [{ paneId: '%2', title: 'manual-shell', command: 'zsh' }];
+    const projectRoot = firstPane ? '/repo' : '/other-repo';
+
+    const reopening = reopenWorktree({
+      slug: 'reopen-me',
+      worktreePath: `${projectRoot}/.dmux/worktrees/reopen-me`,
+      projectRoot,
+      existingPanes: firstPane ? [] : [{ id: 'dmux-0', slug: 'existing', prompt: '', paneId: '%9' }],
+      sessionProjectRoot: '/repo',
+      sessionConfigPath: '/repo/.dmux/dmux.config.json',
+    });
+
+    // Poll while the first startup delay is still pending, before config can
+    // contain the reopened pane. A genuine user-created shell is still found.
+    await vi.advanceTimersByTimeAsync(0);
+    const duringStartup = await getUntrackedPanes('dmux-test', [], '%0');
+    await vi.runAllTimersAsync();
+    const { pane } = await reopening;
+    expect(duringStartup).toEqual(manualShell);
+
+    // The caller saves the returned pane later. Do not drop the guard at the
+    // end of reopenWorktree and reintroduce the same race during that save.
+    expect(title).toBe(`${DMUX_BOOTSTRAP_PANE_TITLE_PREFIX}reopen-me`);
+    expect(await getUntrackedPanes('dmux-test', [], '%0')).toEqual(manualShell);
+    expect(pane.worktreePath).toBe(`${projectRoot}/.dmux/worktrees/reopen-me`);
+    expect(pane.mergeTargetChain).toEqual([{ branchName: 'main', worktreePath: '/repo' }]);
+    expect(pane.type).not.toBe('shell');
   });
 
   it('uses stored agent metadata and permission mode for resume', async () => {

--- a/src/utils/reopenWorktree.ts
+++ b/src/utils/reopenWorktree.ts
@@ -10,7 +10,7 @@ import {
 import { SIDEBAR_WIDTH, recalculateAndApplyLayout } from './layoutManager.js';
 import type { DmuxPane, DmuxConfig } from '../types.js';
 import { atomicWriteJsonSync } from './atomicWrite.js';
-import { buildWorktreePaneTitle } from './paneTitle.js';
+import { DMUX_BOOTSTRAP_PANE_TITLE_PREFIX } from './paneBootstrapConfig.js';
 import {
   AGENT_IDS,
   buildAgentResumeOrLaunchCommand,
@@ -119,7 +119,6 @@ export async function reopenWorktree(
 
   if (isFirstContentPane) {
     paneInfo = setupSidebarLayout(controlPaneId, projectRoot);
-    await new Promise((resolve) => setTimeout(resolve, 300));
   } else {
     // Subsequent panes - always split horizontally
     const dmuxPaneIds = existingPanes.map(p => p.paneId);
@@ -127,17 +126,19 @@ export async function reopenWorktree(
     paneInfo = splitPane({ targetPane });
   }
 
-  await new Promise((resolve) => setTimeout(resolve, 500));
-
-  // Set pane title
+  // Guard the pane before any startup delay so shell detection cannot adopt it
+  // before the caller saves it. enforcePaneTitles applies the normal title
+  // once the pane is tracked in config.
   try {
-    const paneTitle = projectRoot === sessionProjectRoot
-      ? slug
-      : buildWorktreePaneTitle(slug, projectRoot, paneProjectName);
-    await tmuxService.setPaneTitle(paneInfo, paneTitle);
+    await tmuxService.setPaneTitle(paneInfo, `${DMUX_BOOTSTRAP_PANE_TITLE_PREFIX}${slug}`);
   } catch {
     // Ignore if setting title fails
   }
+
+  if (isFirstContentPane) {
+    await new Promise((resolve) => setTimeout(resolve, 300));
+  }
+  await new Promise((resolve) => setTimeout(resolve, 500));
 
   // Apply optimal layout
   if (controlPaneId) {


### PR DESCRIPTION
Fixes #112.

Reopened worktree panes can be adopted as ordinary shells before their config is saved, losing worktree metadata and Merge/Create PR actions.

This sets the existing dmux-bootstrap: title before either startup delay and retains it until the caller saves the pane. The existing title-sync flow then restores the normal title. Two new regression cases cover first/additional panes, startup and pre-save polling, manual-shell detection, and preserved worktree/merge-target metadata.

Validation:
- pnpm run typecheck passed.
- An independent reproduction using the actual production TypeScript fails both scenarios on base 8cb3d926 and passes both with the fix, with normal exit statuses.
- Focused Vitest files report 5 passing cases, but the runner hangs and times out. The unchanged shellPaneDetection.test.ts also hangs alone.
- A single-thread/non-isolated full-suite attempt failed and timed out. Normal full-suite validation is still outstanding.
- git diff --check and patch reverse-application check passed.

Please keep this as a draft until normal CI or maintainer validation completes the test-suite check.