### PR TITLE
fix: name worktree terminals after their source pane

### DIFF
--- a/src/hooks/useInputHandling.ts
+++ b/src/hooks/useInputHandling.ts
@@ -315,6 +315,9 @@ export function useInputHandling(params: UseInputHandlingParams) {
       shellPane.projectName = path.basename(targetProjectRoot)
       shellPane.shellCwd = selectedPane.worktreePath
       shellPane.colorTheme = resolveProjectColorTheme(targetProjectRoot, sidebarProjects)
+      // Keep the source worktree recognizable until terminal auto-naming takes over.
+      shellPane.displayName = `${getPaneDisplayName(selectedPane)}-${shellPane.slug}`
+      shellPane.displayNameSource = "auto"
       await savePanes([...panes, shellPane])
 
       setStatusMessage(`Opened terminal in ${getPaneDisplayName(selectedPane)}`)


### PR DESCRIPTION
Relates to #94.

Initialize new worktree terminal display names from the source pane and unique shell slug. Preserve stable IDs and allow normal automatic renaming. This addresses initial naming; hierarchical grouping is outside this change.

Validation: typecheck and 20 related tests passed. Full suite: 709 passed, 1 failed, 19 skipped. The unmodified upstream has the identical failure in gitOperations.test.ts AI commit message generation; PR #103 already addresses that test. Real tmux E2E was not enabled.

Patch CI: https://github.com/cookerpapa/dmux/actions/runs/34433659057
Upstream baseline: https://github.com/cookerpapa/dmux/actions/runs/34433250669