### PR TITLE
fix: pass kebab menu data through a temporary file

### DIFF
--- a/__tests__/kebabMenuPopup.entry.test.ts
+++ b/__tests__/kebabMenuPopup.entry.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const mocks = vi.hoisted(() => ({ render: vi.fn() }));
+vi.mock('ink', async (importOriginal) => ({
+  ...await importOriginal<typeof import('ink')>(),
+  render: mocks.render,
+}));
+
+const originalArgv = process.argv;
+const directories: string[] = [];
+
+afterEach(() => {
+  process.argv = originalArgv;
+  vi.restoreAllMocks();
+  mocks.render.mockReset();
+  for (const directory of directories.splice(0)) fs.rmSync(directory, { recursive: true, force: true });
+});
+
+describe('kebab menu popup entry point', () => {
+  it('loads pane name and actions from the supplied data file', async () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'dmux-kebab-entry-'));
+    directories.push(directory);
+    const dataFile = path.join(directory, 'menu data.json');
+    const resultFile = path.join(directory, 'result.json');
+    const data = {
+      paneName: '菜单 "quoted" \\ name',
+      actions: [{ id: 'close', label: 'Close', description: 'large menu '.repeat(400), shortcut: 'x' }],
+    };
+    fs.writeFileSync(dataFile, JSON.stringify(data));
+    process.argv = [process.execPath, fileURLToPath(new URL('../src/components/popups/kebabMenuPopup.tsx', import.meta.url)), resultFile, dataFile];
+    vi.spyOn(process, 'exit').mockImplementation(() => { throw new Error('unexpected exit'); });
+    vi.resetModules();
+
+    await import('../src/components/popups/kebabMenuPopup.js');
+
+    expect(mocks.render).toHaveBeenCalledOnce();
+    expect(mocks.render.mock.calls[0][0].props).toEqual(expect.objectContaining({ resultFile, ...data }));
+  });
+
+  it.each(['missing', 'invalid'])('reports an error for a %s data file', async (kind) => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'dmux-kebab-entry-'));
+    directories.push(directory);
+    const dataFile = path.join(directory, 'data.json');
+    if (kind === 'invalid') fs.writeFileSync(dataFile, '{');
+    process.argv = [process.execPath, fileURLToPath(new URL('../src/components/popups/kebabMenuPopup.tsx', import.meta.url)), path.join(directory, 'result.json'), dataFile];
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const exit = vi.spyOn(process, 'exit').mockImplementation(() => { throw new Error('popup exit'); });
+    vi.resetModules();
+
+    await expect(import('../src/components/popups/kebabMenuPopup.js')).rejects.toThrow('popup exit');
+
+    expect(error).toHaveBeenCalledWith('Error: Failed to read or parse data file');
+    expect(exit).toHaveBeenCalledWith(1);
+    expect(mocks.render).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/popupManager.kebabMenu.test.ts
+++ b/__tests__/popupManager.kebabMenu.test.ts
@@ -1,4 +1,12 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import fs from 'fs';
+
+const popupMocks = vi.hoisted(() => ({ launch: vi.fn() }));
+vi.mock('../src/utils/popup.js', () => ({
+  launchNodePopupNonBlocking: popupMocks.launch,
+  POPUP_POSITIONING: { standard: () => ({}) },
+}));
+
 import { PopupManager, type PopupManagerConfig } from '../src/services/PopupManager.js';
 import type { DmuxPane } from '../src/types.js';
 
@@ -36,6 +44,8 @@ function createPane(id: string): DmuxPane {
 }
 
 describe('PopupManager launchKebabMenuPopup', () => {
+  afterEach(() => vi.restoreAllMocks());
+
   it('anchors the popup to the target pane when requested', async () => {
     const manager = createPopupManager() as any;
     const pane = createPane('1');
@@ -48,21 +58,50 @@ describe('PopupManager launchKebabMenuPopup', () => {
 
     await manager.launchKebabMenuPopup(pane, [pane], { anchorToPane: true });
 
-    const [, popupArgs, popupOptions] = manager.launchPopup.mock.calls[0];
-    const actions = JSON.parse(popupArgs[1]);
+    const [, , , popupData] = manager.launchPopup.mock.calls[0];
+    const { actions } = popupData;
 
     expect(manager.launchPopup).toHaveBeenCalledWith(
       'kebabMenuPopup.js',
-      ['Pane 1', expect.any(String)],
+      [],
       expect.objectContaining({
         width: 60,
-        height: Math.min(21, actions.length + 6),
+        height: Math.min(26, actions.length + 6),
         title: 'Menu: Pane 1',
         positioning: 'pane',
         targetPaneId: pane.paneId,
       }),
-      undefined,
+      { paneName: 'Pane 1', actions },
       '/tmp/project'
     );
+  });
+
+  it.each(['selected', 'cancelled', 'launch failed'])('passes menu data through a file and cleans it up when %s', async (outcome) => {
+    const manager = createPopupManager();
+    const pane = createPane('1');
+    pane.displayName = '菜单 "quoted" \\ name';
+    let dataFile = '';
+    popupMocks.launch.mockImplementation((_script, args) => {
+      expect(args).toHaveLength(1);
+      dataFile = args[0];
+      const data = JSON.parse(fs.readFileSync(dataFile, 'utf8'));
+      expect(data.paneName).toBe(pane.displayName);
+      expect(data.actions.length).toBeGreaterThan(1);
+      expect(data.actions).toContainEqual(expect.objectContaining({ id: 'close' }));
+      expect(JSON.stringify(args).length).toBeLessThan(JSON.stringify(data).length);
+      if (outcome === 'launch failed') throw new Error('popup failed');
+      return {
+        readyPromise: Promise.resolve(),
+        resultPromise: Promise.resolve(outcome === 'selected'
+          ? { success: true, data: 'close' }
+          : { success: false, cancelled: true }),
+      };
+    });
+
+    const result = await manager.launchKebabMenuPopup(pane, [pane]);
+
+    expect(dataFile).not.toBe('');
+    expect(fs.existsSync(dataFile)).toBe(false);
+    expect(result).toBe(outcome === 'selected' ? 'close' : null);
   });
 });

--- a/src/components/popups/kebabMenuPopup.tsx
+++ b/src/components/popups/kebabMenuPopup.tsx
@@ -11,6 +11,7 @@ import type { PaneMenuAction } from '../../actions/types.js';
 import { PopupContainer, PopupWrapper, writeSuccessAndExit } from './shared/index.js';
 import { POPUP_CONFIG } from './config.js';
 import { pathToFileURL } from 'url';
+import fs from 'fs';
 import {
   createMouseFilteredStdin,
   MOUSE_REPORTING_ENABLE,
@@ -112,19 +113,18 @@ export const KebabMenuPopupApp: React.FC<KebabMenuPopupProps> = ({ resultFile, p
 // Entry point
 function main() {
   const resultFile = process.argv[2];
-  const paneName = process.argv[3];
-  const actionsJson = process.argv[4];
+  const dataFile = process.argv[3];
 
-  if (!resultFile || !paneName || !actionsJson) {
-    console.error('Error: Result file, pane name, and actions JSON required');
+  if (!resultFile || !dataFile) {
+    console.error('Error: Result file and data file required');
     process.exit(1);
   }
 
-  let actions: PaneMenuAction[];
+  let data: { paneName: string; actions: PaneMenuAction[] };
   try {
-    actions = JSON.parse(actionsJson);
+    data = JSON.parse(fs.readFileSync(dataFile, 'utf-8'));
   } catch (error) {
-    console.error('Error: Failed to parse actions JSON');
+    console.error('Error: Failed to read or parse data file');
     process.exit(1);
   }
 
@@ -141,8 +141,8 @@ function main() {
   render(
     <KebabMenuPopupApp
       resultFile={resultFile}
-      paneName={paneName}
-      actions={actions}
+      paneName={data.paneName}
+      actions={data.actions}
       mouseEvents={mouseFilter?.events}
     />,
     mouseFilter ? { stdin: mouseFilter.stdin } : undefined

--- a/src/services/PopupManager.ts
+++ b/src/services/PopupManager.ts
@@ -416,7 +416,7 @@ export class PopupManager {
       )
       const result = await this.launchPopup<string>(
         "kebabMenuPopup.js",
-        [getPaneDisplayName(pane), JSON.stringify(actions)],
+        [],
         {
           width: 60,
           height: Math.min(26, actions.length + 6),
@@ -424,7 +424,7 @@ export class PopupManager {
           positioning: options.anchorToPane ? "pane" : "standard",
           targetPaneId: options.anchorToPane ? pane.paneId : undefined,
         },
-        undefined,
+        { paneName: getPaneDisplayName(pane), actions },
         getPaneProjectRoot(pane, this.config.projectRoot)
       )
 


### PR DESCRIPTION
Fixes #111.

The kebab popup currently puts its full action list in the command line. This is the long-argument launch path identified in the report about menus being terminated on repeated opens.

Pass `{ paneName, actions }` through the existing popup temporary-data mechanism and read that file in the popup entry point. Menu positioning, selection and result handling stay the same. The shared launcher removes the file on selection, cancellation and launch failure.

Add regression coverage for the manager-to-file path, cleanup and the entry point's file loading/error handling. Update the existing anchor test for the new data argument and the already-current 26-row height limit.

Validation:
- TypeScript compilation and the runtime-parity guard pass.
- A real compiled popup in a PTY loads a 5,517-byte data file, accepts the close shortcut, writes the correct result and exits with status 0.
- The two focused Vitest files report all 7 cases passing, but the local worker pool hangs before the final report and times out. This runner problem also occurs on unchanged dmux tests; a completed suite run is still needed.
- The reported macOS endpoint-security environment has not been reproduced here.