### PR TITLE
fix: keep sidebar responsive during PR creation

### DIFF
--- a/__tests__/actions/createPullRequestAction.test.ts
+++ b/__tests__/actions/createPullRequestAction.test.ts
@@ -70,7 +70,7 @@ describe('createPullRequestAction', () => {
       message: 'Committed changes',
       dismissable: true,
     });
-    mocked.createGitHubPullRequest.mockReturnValue({
+    mocked.createGitHubPullRequest.mockResolvedValue({
       url: 'https://github.com/acme/repo/pull/123',
       created: true,
       remoteName: 'origin',
@@ -197,7 +197,7 @@ describe('createPullRequestAction', () => {
   it('surfaces an existing PR instead of treating it as a failure', async () => {
     const pane = createWorktreePane({ branchName: 'feature/review-queue' });
     const context = createMockContext([pane]);
-    mocked.createGitHubPullRequest.mockReturnValue({
+    mocked.createGitHubPullRequest.mockResolvedValue({
       url: 'https://github.com/acme/repo/pull/123',
       created: false,
       remoteName: 'origin',
@@ -228,9 +228,7 @@ describe('createPullRequestAction', () => {
   it('returns an error result when GitHub PR creation fails', async () => {
     const pane = createWorktreePane();
     const context = createMockContext([pane]);
-    mocked.createGitHubPullRequest.mockImplementation(() => {
-      throw new Error('GitHub CLI auth failed');
-    });
+    mocked.createGitHubPullRequest.mockRejectedValue(new Error('GitHub CLI auth failed'));
 
     const result = await createPullRequest(pane, context);
     const reviewResult = await result.onConfirm?.();

--- a/__tests__/githubPullRequest.creation.test.ts
+++ b/__tests__/githubPullRequest.creation.test.ts
@@ -1,0 +1,179 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import os from 'os';
+import path from 'path';
+import { createGitHubPullRequest, getPreferredPushRemote } from '../src/utils/githubPullRequest.js';
+
+interface CommandResponse {
+  command: string;
+  args: string[];
+  stdout?: string;
+  stderr?: string;
+  status?: number;
+  waitForHeartbeat?: boolean;
+}
+
+// Run real child processes without contacting GitHub or changing a repository.
+const commandFixture = `#!${process.execPath}
+const fs = require('fs');
+const path = require('path');
+const command = path.basename(process.argv[1]);
+const args = process.argv.slice(2);
+const responses = JSON.parse(fs.readFileSync('responses.json', 'utf8'));
+const response = responses.shift();
+fs.writeFileSync('responses.json', JSON.stringify(responses));
+if (!response || response.command !== command || JSON.stringify(response.args) !== JSON.stringify(args)) {
+  process.stderr.write('Unexpected command: ' + JSON.stringify({ command, args }));
+  process.exit(99);
+}
+function finish() {
+  process.stdout.write(response.stdout || '');
+  process.stderr.write(response.stderr || '');
+  process.exit(response.status || 0);
+}
+if (response.waitForHeartbeat) {
+  fs.writeFileSync('command-pending', '');
+  const deadline = Date.now() + 2000;
+  const timer = setInterval(() => {
+    if (fs.existsSync('heartbeat') || Date.now() >= deadline) {
+      clearInterval(timer);
+      fs.writeFileSync('responsive.json', JSON.stringify(fs.existsSync('heartbeat')));
+      fs.unlinkSync('command-pending');
+      finish();
+    }
+  }, 10);
+} else {
+  finish();
+}
+`;
+
+describe.skipIf(process.platform === 'win32')('GitHub PR commands', () => {
+  let repoPath: string;
+  const sourceBranch = 'feature/review-queue';
+  const url = 'https://github.com/acme/repo/pull/123';
+  const version: CommandResponse = { command: 'gh', args: ['--version'], stdout: 'gh version 2.0' };
+  const view: CommandResponse = {
+    command: 'gh', args: ['pr', 'view', sourceBranch, '--json', 'url', '--jq', '.url'],
+  };
+  const remote: CommandResponse = {
+    command: 'git', args: ['ls-remote', '--heads', 'origin', 'main'], stdout: 'abc refs/heads/main\n',
+  };
+  const push: CommandResponse = {
+    command: 'git', args: ['push', '--set-upstream', 'origin', sourceBranch],
+  };
+  const create: CommandResponse = {
+    command: 'gh', args: ['pr', 'create', '--base', 'main', '--head', sourceBranch, '--fill'],
+  };
+
+  function setResponses(responses: CommandResponse[]) {
+    writeFileSync(path.join(repoPath, 'responses.json'), JSON.stringify(responses));
+  }
+
+  function options() {
+    return { repoPath, sourceBranch, targetBranch: 'main', remoteName: 'origin' };
+  }
+
+  beforeEach(() => {
+    repoPath = mkdtempSync(path.join(os.tmpdir(), 'dmux-pr-'));
+    const binPath = path.join(repoPath, 'bin');
+    mkdirSync(binPath);
+    for (const command of ['git', 'gh']) {
+      writeFileSync(path.join(binPath, command), commandFixture, { mode: 0o755 });
+    }
+    vi.stubEnv('PATH', `${binPath}${path.delimiter}${process.env.PATH || ''}`);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    rmSync(repoPath, { recursive: true, force: true });
+  });
+
+  it('keeps the event loop responsive during a push and preserves title/body arguments', async () => {
+    const title = 'fix: keep $variables and `backticks` literal';
+    const body = 'First line\n\nQuotes: "text"; $(literal text)';
+    setResponses([
+      version,
+      { ...view, status: 1 },
+      remote,
+      { ...push, waitForHeartbeat: true },
+      { ...create, args: [...create.args.slice(0, -1), '--title', title, '--body', body] },
+      { ...view, stdout: `${url}\n` },
+    ]);
+    const timer = setInterval(() => {
+      if (existsSync(path.join(repoPath, 'command-pending'))) {
+        writeFileSync(path.join(repoPath, 'heartbeat'), '');
+      }
+    }, 5);
+
+    try {
+      const result = await createGitHubPullRequest({ ...options(), title, body });
+      expect(result).toEqual({ url, created: true, remoteName: 'origin' });
+      expect(JSON.parse(readFileSync(path.join(repoPath, 'responsive.json'), 'utf8'))).toBe(true);
+      expect(JSON.parse(readFileSync(path.join(repoPath, 'responses.json'), 'utf8'))).toEqual([]);
+    } finally {
+      clearInterval(timer);
+    }
+  });
+
+  it('returns an existing PR without pushing or creating another', async () => {
+    setResponses([version, { ...view, stdout: url }]);
+    await expect(createGitHubPullRequest(options())).resolves.toEqual({ url, created: false, remoteName: 'origin' });
+  });
+
+  it('rejects a missing target branch before pushing', async () => {
+    setResponses([version, { ...view, status: 1 }, { ...remote, stdout: '' }]);
+    await expect(createGitHubPullRequest(options())).rejects.toThrow('Remote branch origin/main was not found');
+  });
+
+  it.each(['stderr', 'stdout'] as const)('reports push errors from %s without creating a PR', async (stream) => {
+    setResponses([version, { ...view, status: 1 }, remote, { ...push, status: 1, [stream]: 'Push rejected' }]);
+    await expect(createGitHubPullRequest(options())).rejects.toThrow('Push rejected');
+  });
+
+  it('returns a PR created concurrently when creation fails', async () => {
+    setResponses([version, { ...view, status: 1 }, remote, push, { ...create, status: 1 }, { ...view, stdout: url }]);
+    await expect(createGitHubPullRequest(options())).resolves.toEqual({ url, created: false, remoteName: 'origin' });
+  });
+
+  it('preserves the creation error when no PR can be found afterward', async () => {
+    setResponses([version, { ...view, status: 1 }, remote, push, { ...create, status: 1, stderr: 'Permission denied' }, { ...view, status: 1 }]);
+    await expect(createGitHubPullRequest(options())).rejects.toThrow('Permission denied');
+  });
+
+  it('reports when creation succeeds but the URL cannot be determined', async () => {
+    setResponses([version, { ...view, status: 1 }, remote, push, create, { ...view, status: 1 }]);
+    await expect(createGitHubPullRequest(options())).rejects.toThrow('resulting URL could not be determined');
+  });
+
+  it('awaits automatic remote selection when none is supplied', async () => {
+    setResponses([
+      { command: 'git', args: ['rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{upstream}'], stdout: `fork/${sourceBranch}` },
+      version,
+      { ...view, stdout: url },
+    ]);
+    await expect(createGitHubPullRequest({ ...options(), remoteName: undefined })).resolves.toEqual({ url, created: false, remoteName: 'fork' });
+  });
+
+  it.each([
+    { configured: 'fork', remotes: '', expected: 'fork' },
+    { configured: '', remotes: 'upstream\norigin\n', expected: 'origin' },
+    { configured: '', remotes: 'upstream\n', expected: 'upstream' },
+  ])('selects $expected from branch configuration or remotes', async ({ configured, remotes, expected }) => {
+    setResponses([
+      { command: 'git', args: ['rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{upstream}'], status: 1 },
+      { command: 'git', args: ['branch', '--show-current'], stdout: sourceBranch },
+      { command: 'git', args: ['config', `branch.${sourceBranch}.remote`], stdout: configured, status: configured ? 0 : 1 },
+      ...configured ? [] : [{ command: 'git', args: ['remote'], stdout: remotes }],
+    ]);
+    await expect(getPreferredPushRemote(repoPath)).resolves.toBe(expected);
+  });
+
+  it('reports when no remote is configured', async () => {
+    setResponses([
+      { command: 'git', args: ['rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{upstream}'], status: 1 },
+      { command: 'git', args: ['branch', '--show-current'], stdout: '' },
+      { command: 'git', args: ['remote'], stdout: '' },
+    ]);
+    await expect(getPreferredPushRemote(repoPath)).rejects.toThrow('No git remote is configured');
+  });
+});

--- a/src/actions/implementations/createPullRequestAction.ts
+++ b/src/actions/implementations/createPullRequestAction.ts
@@ -204,7 +204,7 @@ export async function createPullRequest(
     body: string | undefined
   ): Promise<ActionResult> => {
     try {
-      const result = createGitHubPullRequest({
+      const result = await createGitHubPullRequest({
         repoPath: pane.worktreePath!,
         sourceBranch,
         targetBranch: mergeTarget.targetBranch,

--- a/src/utils/githubPullRequest.ts
+++ b/src/utils/githubPullRequest.ts
@@ -1,4 +1,4 @@
-import { spawnSync } from 'child_process';
+import { execFile, spawnSync } from 'child_process';
 
 export interface GitHubPullRequestResult {
   url: string;
@@ -91,38 +91,36 @@ function runCommandText(
   command: string,
   args: string[],
   options: CommandOptions
-): string {
-  const result = spawnSync(command, args, {
-    cwd: options.cwd,
-    encoding: 'utf-8',
-    stdio: ['ignore', 'pipe', 'pipe'],
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const child = execFile(command, args, {
+      cwd: options.cwd,
+      encoding: 'utf-8',
+    }, (error, stdout, stderr) => {
+      if (error) {
+        if (options.allowFailure) {
+          resolve('');
+        } else if (typeof error.code === 'number') {
+          reject(new Error(stderr.trim() || stdout.trim() || `${command} exited with status ${error.code}`));
+        } else {
+          reject(error);
+        }
+        return;
+      }
+
+      resolve(stdout.trim());
+    });
+
+    // These commands must not wait for input from the sidebar's terminal.
+    child.stdin?.end();
   });
-
-  if (result.error) {
-    if (options.allowFailure) {
-      return '';
-    }
-    throw result.error;
-  }
-
-  if (result.status !== 0) {
-    if (options.allowFailure) {
-      return '';
-    }
-
-    const stderr = result.stderr?.trim();
-    const stdout = result.stdout?.trim();
-    throw new Error(stderr || stdout || `${command} exited with status ${result.status}`);
-  }
-
-  return result.stdout.trim();
 }
 
 function runGit(
   repoPath: string,
   args: string[],
   options: Omit<CommandOptions, 'cwd'> = {}
-): string {
+): Promise<string> {
   return runCommandText('git', args, { cwd: repoPath, ...options });
 }
 
@@ -130,20 +128,20 @@ function runGh(
   repoPath: string,
   args: string[],
   options: Omit<CommandOptions, 'cwd'> = {}
-): string {
+): Promise<string> {
   return runCommandText('gh', args, { cwd: repoPath, ...options });
 }
 
-function ensureGitHubCliAvailable(repoPath: string): void {
+async function ensureGitHubCliAvailable(repoPath: string): Promise<void> {
   try {
-    runGh(repoPath, ['--version']);
+    await runGh(repoPath, ['--version']);
   } catch {
     throw new Error(buildMissingGitHubCliMessage());
   }
 }
 
-function listGitRemotes(repoPath: string): string[] {
-  const output = runGit(repoPath, ['remote'], { allowFailure: true });
+async function listGitRemotes(repoPath: string): Promise<string[]> {
+  const output = await runGit(repoPath, ['remote'], { allowFailure: true });
 
   return output
     .split('\n')
@@ -151,8 +149,8 @@ function listGitRemotes(repoPath: string): string[] {
     .filter(Boolean);
 }
 
-export function getPreferredPushRemote(repoPath: string): string {
-  const upstream = runGit(
+export async function getPreferredPushRemote(repoPath: string): Promise<string> {
+  const upstream = await runGit(
     repoPath,
     ['rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{upstream}'],
     { allowFailure: true }
@@ -162,12 +160,12 @@ export function getPreferredPushRemote(repoPath: string): string {
     return upstream.split('/')[0];
   }
 
-  const currentBranch = runGit(repoPath, ['branch', '--show-current'], {
+  const currentBranch = await runGit(repoPath, ['branch', '--show-current'], {
     allowFailure: true,
   });
 
   if (currentBranch && currentBranch !== 'HEAD') {
-    const configuredRemote = runGit(
+    const configuredRemote = await runGit(
       repoPath,
       ['config', `branch.${currentBranch}.remote`],
       { allowFailure: true }
@@ -178,7 +176,7 @@ export function getPreferredPushRemote(repoPath: string): string {
     }
   }
 
-  const remotes = listGitRemotes(repoPath);
+  const remotes = await listGitRemotes(repoPath);
   if (remotes.length === 0) {
     throw new Error('No git remote is configured for this repository.');
   }
@@ -186,11 +184,11 @@ export function getPreferredPushRemote(repoPath: string): string {
   return remotes.includes('origin') ? 'origin' : remotes[0];
 }
 
-export function findExistingPullRequestUrl(
+export async function findExistingPullRequestUrl(
   repoPath: string,
   sourceBranch: string
-): string | null {
-  const output = runGh(
+): Promise<string | null> {
+  const output = await runGh(
     repoPath,
     ['pr', 'view', sourceBranch, '--json', 'url', '--jq', '.url'],
     { allowFailure: true }
@@ -200,12 +198,12 @@ export function findExistingPullRequestUrl(
   return url || null;
 }
 
-function ensureRemoteBranchExists(
+async function ensureRemoteBranchExists(
   repoPath: string,
   remoteName: string,
   branchName: string
-): void {
-  const output = runGit(repoPath, ['ls-remote', '--heads', remoteName, branchName]);
+): Promise<void> {
+  const output = await runGit(repoPath, ['ls-remote', '--heads', remoteName, branchName]);
 
   if (!output.trim()) {
     throw new Error(
@@ -214,26 +212,26 @@ function ensureRemoteBranchExists(
   }
 }
 
-export function createGitHubPullRequest(options: {
+export async function createGitHubPullRequest(options: {
   repoPath: string;
   sourceBranch: string;
   targetBranch: string;
   remoteName?: string;
   title?: string;
   body?: string;
-}): GitHubPullRequestResult {
+}): Promise<GitHubPullRequestResult> {
   const {
     repoPath,
     sourceBranch,
     targetBranch,
-    remoteName = getPreferredPushRemote(repoPath),
+    remoteName = await getPreferredPushRemote(repoPath),
     title,
     body,
   } = options;
 
-  ensureGitHubCliAvailable(repoPath);
+  await ensureGitHubCliAvailable(repoPath);
 
-  const existingUrl = findExistingPullRequestUrl(repoPath, sourceBranch);
+  const existingUrl = await findExistingPullRequestUrl(repoPath, sourceBranch);
   if (existingUrl) {
     return {
       url: existingUrl,
@@ -242,9 +240,9 @@ export function createGitHubPullRequest(options: {
     };
   }
 
-  ensureRemoteBranchExists(repoPath, remoteName, targetBranch);
+  await ensureRemoteBranchExists(repoPath, remoteName, targetBranch);
 
-  runGit(repoPath, ['push', '--set-upstream', remoteName, sourceBranch]);
+  await runGit(repoPath, ['push', '--set-upstream', remoteName, sourceBranch]);
 
   const hasExplicitTitle = typeof title === 'string' && title.trim().length > 0;
   const createArgs = [
@@ -264,9 +262,9 @@ export function createGitHubPullRequest(options: {
   }
 
   try {
-    runGh(repoPath, createArgs);
+    await runGh(repoPath, createArgs);
   } catch (error) {
-    const existingAfterCreate = findExistingPullRequestUrl(repoPath, sourceBranch);
+    const existingAfterCreate = await findExistingPullRequestUrl(repoPath, sourceBranch);
     if (existingAfterCreate) {
       return {
         url: existingAfterCreate,
@@ -278,7 +276,7 @@ export function createGitHubPullRequest(options: {
     throw error;
   }
 
-  const createdUrl = findExistingPullRequestUrl(repoPath, sourceBranch);
+  const createdUrl = await findExistingPullRequestUrl(repoPath, sourceBranch);
   if (!createdUrl) {
     throw new Error('Pull request was created but the resulting URL could not be determined.');
   }


### PR DESCRIPTION
Creating a PR blocks the sidebar while synchronous git and gh commands wait for network operations. The UI cannot process input or update its activity indicator during remote checks, push, or PR creation.

Run the command chain asynchronously with execFile and await it in the action handler. Preserve argument arrays, closed stdin, remote selection, existing-PR recovery, and error reporting.

Fixes #91.

Validation:
- 31 focused tests passed, including real child processes that check event-loop responsiveness during a pending push. The regression fails on unchanged main.
- TypeScript, runtime parity guard, and diff checks passed.
- Full suite: 721 passed, 19 skipped, 2 failed. Both failures reproduce on unchanged main: paneRestore.test.ts (restored command expectation) and integration/gitOperations.test.ts (AI commit message mock).

Tests use local fake git/gh executables and do not contact GitHub.